### PR TITLE
change orientation preference to "default"

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -8,7 +8,7 @@
     Fraunhofer FOKUS
     </author>
     <content src="sender.html" />
-    <preference name="Orientation" value="both" />
+    <preference name="Orientation" value="default" />
     <preference name="DisallowOverscroll" value="true"/>
     <access origin="*" />
     <feature name="Presentation">


### PR DESCRIPTION
"both" is not (no longer?) a valid value for orientation in config.xml

I was unable to build for Android without changing this value. "default" has been working fine.